### PR TITLE
Add network policy and schedule tolerations

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,4 +1,4 @@
-# Kubernetes al-agent-container Deplyoment
+# Kubernetes al-agent-container Deployment
 
 Deploying the al-agent-container for IDS on a Kubernetes cluster is accomplished using a _DaemonSet_ in Kubernetes.  A _DaemonSet_ ensures that one al-agent-container is running on each physical node in the cluster.
 
@@ -15,3 +15,14 @@ To verify agent deployment and operation:
 1. Confirm that the _DaemonSet_ is defined: ```kubectl describe daemonset al-agent-container```
 2. Confirm that the _Pod_ is defined: ```kubectl get pods```
 3. Pick one of the _al-agent-container_ pods, and run: ```kubectl logs -f <pod name>```
+
+Network Policy Exception (AWS)
+=========================
+If you are using Calico or Weave as your CNI, your default Network Policy may deny the pods access to the ec2 metadata.
+
+You need to add exception to allow _al-agent-container_ pods to access the ec2 instance metadata.
+
+To create new Network Policy:
+
+1. Edit netpol-al-agent-container.yaml and replace the namespace to match your deployment namespace.
+2. Run the following command: ```kubectl create -f netpol_agent_metadata.yaml```

--- a/kubernetes/al-agent-container.yaml
+++ b/kubernetes/al-agent-container.yaml
@@ -46,3 +46,6 @@ spec:
           path: /proc
           type: Directory
       restartPolicy: Always
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule

--- a/kubernetes/netpol-al-agent-container.yaml
+++ b/kubernetes/netpol-al-agent-container.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: al-agent-container-access-ec2-metadata
+spec:
+  podSelector:
+    matchLabels:
+      app: al-agent-container
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 169.254.169.254/32
+    - namespaceSelector:
+        matchLabels:
+          project: default
+    - podSelector:
+        matchLabels:
+          app: al-agent-container
+    ports:
+    - protocol: TCP
+      port: 80


### PR DESCRIPTION
**Schedule tolerations**
al-agent-container ideally should run on all nodes including master and worker.
to accommodate scenario where the master is tainted from running pods from user namespace, this pull request will add toleration in the daemonset.

**Network policy**
al-agent-container requires access to ec2 instance metadata.
the default network policy may block this access, this pull request includes sample on how to make this exception.

