### PR TITLE
Remove Unnecessary Kubernetes Configuration Parameter

### DIFF
--- a/kubernetes/al-agent-container.yaml
+++ b/kubernetes/al-agent-container.yaml
@@ -35,8 +35,6 @@ spec:
         - mountPath: /host/proc
           name: docker-proc-volume
         imagePullPolicy: Always
-      imagePullSecrets:
-        - name: regcred
       volumes:
       - name: docker-sock-volume
         hostPath:


### PR DESCRIPTION
imagePullSecrets for Kubernetes is no longer necessary.