### PR TITLE
Fix container EPERM errors

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -16,9 +16,7 @@ Use the following procedure to deploy the Agent Container to a single Docker hos
 	  --name=al-agent-container \
 	  --label "app=al-agent-container" \
 	  --net=bridge \
-	  --cap-add=SYS_ADMIN \
-	  --cap-add=NET_ADMIN \
-	  --cap-add=NET_BIND_SERVICE \
+	  --privileged \
 	  --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
 	  --mount type=bind,source=/proc,target=/host/proc \
 	  --memory-reservation=100m \

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,7 @@ Use the following procedure to deploy the Agent Container to a single Docker hos
 	docker run \
 	  --name=al-agent-container \
 	  --label "app=al-agent-container" \
-	  --net=bridge \
+	  --net=host \
 	  --privileged \
 	  --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
 	  --mount type=bind,source=/proc,target=/host/proc \

--- a/ecs/al-agent-ecs.json
+++ b/ecs/al-agent-ecs.json
@@ -6,15 +6,7 @@
       "cpu": 10,
       "memory": 500,
       "essential": true,
-      "linuxParameters": {
-        "capabilities": {
-          "add": [
-            "SYS_ADMIN",
-            "NET_ADMIN",
-            "NET_BIND_SERVICE"
-          ]
-        }
-      },
+      "privileged": true,
       "mountPoints": [
         {
           "containerPath": "/var/run/docker.sock",

--- a/kubernetes/al-agent-container.yaml
+++ b/kubernetes/al-agent-container.yaml
@@ -24,11 +24,7 @@ spec:
           - name: KEY
             value: "your_registration_key_here"
         securityContext:
-          capabilities:
-            add:
-            - SYS_ADMIN
-            - NET_ADMIN
-            - NET_BIND_SERVICE
+          privileged: true
         volumeMounts:
         - mountPath: /var/run/docker.sock
           name: docker-sock-volume


### PR DESCRIPTION
@fss18 @ericreeves
Problem: During testing of 2.8.1 build on a K8s cluster, it was discovered that some container namespaces fail to open with EPERM errors despite having SYS_ADMIN capability, which prevents us from collecting their IP addresses (and, if those containers are the only ones in their namespace, from binding their interfaces). Adding other relevant capabilities (DAC_OVERRIDE, DAC_READ_SEARCH, FOWNER, IPC_OWNER) did not help. After experimenting with *all* capabilities listed at http://man7.org/linux/man-pages/man7/capabilities.7.html, the required capability turned out to be SYS_PTRACE (!) which neither the above page, nor http://man7.org/linux/man-pages/man2/setns.2.html, nor http://man7.org/linux/man-pages/man2/open.2.html mention as a requirement for setns() or open(); the only obscure reference can be found at http://man7.org/linux/man-pages/man7/namespaces.7.html and it doesn't mention capabilities directly.
So far, I've only seen failures to open namespaces on some K8s auxiliary containers (specifically k8s_kube-proxy and k8s_sidecar_kube-dns).

Solution: Revert to fully privileged mode to avoid obscure failures like this in the future.

Additional change: For vanilla Docker, change recommended mode from bridge to host to make the agent capture the base host interfaces. (This is not necessary for K8s or ECS because both have at least 1 host-mode container, therefore host intefaces should be captured as is.)