### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains definitions and instructions to deploy the Alert Logic 
 - Kubernetes
 - Amazon Elastic Container Service (ECS)
 - Docker
-- Amazon Elastic Beanstalk (EB) multi containers
+- AWS Elastic Beanstalk Multicontainer Docker Platform
 
 # Prerequisites
 


### PR DESCRIPTION
I edited the bullet for Elastic Beanstalk to be consistent with AWS style and usage of "multicontainer." If the EB document does not refer specifically to a multicontainer Docker platform, we can make a change.