### PR TITLE
updated readme with support for gcp/gke

### DIFF
--- a/SupportedPlatforms.md
+++ b/SupportedPlatforms.md
@@ -6,6 +6,6 @@ Amazon Web Services | Microsoft Azure | On-Premise | Google Cloud Platform
 ------------------- | --------------- | ---------- | ---------------------
 [Amazon Elastic Container Service for Kubernetes](https://github.com/alertlogic/al-agent-container/tree/master/kubernetes) (Amazon EKS) | [Azure Kubernetes Service](https://github.com/alertlogic/al-agent-container/tree/master/kubernetes) (AKS) | [Kubernetes](https://github.com/alertlogic/al-agent-container/tree/master/kubernetes) | [Google Kubernetes Engine](https://github.com/alertlogic/al-agent-container/tree/master/kubernetes) (GKE)
 [Amazon Elastic Container Service](https://github.com/alertlogic/al-agent-container/tree/master/ecs) (Amazon ECS) | [Kubernetes ACS-Engine](https://github.com/alertlogic/al-agent-container/tree/master/kubernetes) | CoreOS |
-AWS Elastic Beanstalk for Multicontainer Docker Environments | CoreOS on Azure | |
+[AWS Elastic Beanstalk for Multicontainer Docker Environments](https://github.com/alertlogic/al-agent-container/tree/master/elasticbeanstalk) | CoreOS on Azure | |
 [Kubernetes deployed on AWS EC2 instances](https://github.com/alertlogic/al-agent-container/tree/master/kubernetes) | | |
 CoreOS deployed on AWS EC2 instances | | |

--- a/SupportedPlatforms.md
+++ b/SupportedPlatforms.md
@@ -2,10 +2,10 @@
 
 Alert Logic supports the Alert Logic Agent Container on the following orchestration and operating environments:
 
-Amazon Web Services | Microsoft Azure | On-Premise
-------------------- | --------------- | ----------
-Amazon Elastic Container Service for Kubernetes (Amazon EKS) | Azure Kubernetes Service (AKS) | Kubernetes
-Amazon Elastic Container Service (Amazon ECS) | Kubernetes ACS-Engine | CoreOS
-AWS Elastic Beanstalk for Multicontainer Docker Environments | CoreOS on Azure |
-Kubernetes deployed on AWS EC2 instances | |
-CoreOS deployed on AWS EC2 instances | |
+Amazon Web Services | Microsoft Azure | On-Premise | Google Cloud Platform
+------------------- | --------------- | ---------- | ---------------------
+[Amazon Elastic Container Service for Kubernetes](https://github.com/alertlogic/al-agent-container/tree/master/kubernetes) (Amazon EKS) | [Azure Kubernetes Service](https://github.com/alertlogic/al-agent-container/tree/master/kubernetes) (AKS) | [Kubernetes](https://github.com/alertlogic/al-agent-container/tree/master/kubernetes) | [Google Kubernetes Engine](https://github.com/alertlogic/al-agent-container/tree/master/kubernetes) (GKE)
+[Amazon Elastic Container Service](https://github.com/alertlogic/al-agent-container/tree/master/ecs) (Amazon ECS) | [Kubernetes ACS-Engine](https://github.com/alertlogic/al-agent-container/tree/master/kubernetes) | CoreOS |
+AWS Elastic Beanstalk for Multicontainer Docker Environments | CoreOS on Azure | |
+[Kubernetes deployed on AWS EC2 instances](https://github.com/alertlogic/al-agent-container/tree/master/kubernetes) | | |
+CoreOS deployed on AWS EC2 instances | | |

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -7,7 +7,7 @@ This directory contains the al-agent-container.yaml file, which is the YAML defi
 ## Before You Begin
 - You must have the kubectl command line interface installed and get authentication credentials to interact with the cluster where you want to install the Agent Container.
 - Download the al-agent-container.yaml file.
-- To deploy the Alert Logic Agent Container for Kubernetes, you need your Alert Logic account's unique registration key.
+- To deploy the Alert Logic Agent Container for Kubernetes, you need the unique registration key for your Alert Logic account.
 
 **To find your unique registration key:**
 1. In the Alert Logic console, click the Support Information icon.
@@ -16,14 +16,14 @@ This directory contains the al-agent-container.yaml file, which is the YAML defi
 
 ## Deploy the Agent Container
 **To deploy the Agent Container to your cluster:**
-1. Edit the al-agent-container.yaml file to replace "your_registration_key_here" with your Alert Logic account's unique registration key.
+1. Edit the al-agent-container.yaml file to replace "your_registration_key_here" with the unique registration key for your Alert Logic Account
 2. In the command line, type  ```kubectl get pods``` to ensure kubectl communicates with the proper Kubernetes cluster.
 3. In the command line, type ```kubectl apply -f al-agent-container.yaml```.
 
 **To verify agent deployment and operation:**
 1. In the command line, type ```kubectl describe daemonset al-agent-container``` to confirm the DaemonSet definition.
 2. In the command line, type ```kubectl get pods``` to confirm the Agent Container pod is running on every expected host in your cluster.
-3. In the command line, in one of the pods, type ```kubectl logs -f <agent's_pod_name>``` to confirm the Agent Container was registered successfully. Example of successful logs:
+3. In the command line, type ```kubectl logs -l app=al-agent-container``` to confirm the Agent Container was registered successfully. Example of successful logs:
 
 ```
 Oct 14 02:35:55 2018 al-agent[5]: ALC00083I [alc_config_unregister] clean up registration artefacts

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -5,27 +5,67 @@ To deploy the Alert Logic Agent Container on a Kubernetes cluster, you must use 
 This directory contains the al-agent-container.yaml file, which is the YAML definition you need to download and edit. This file allows the Kubernetes `DaemonSet` to deploy the agent.
 
 ## Before You Begin
-- You must have the kubectl command line interface installed and pointed to the cluster to which you want to install the Agent Container.
-- Download the al-agent-container.yaml file and the netpol_agent_metadata.yaml file. 
-- To deploy the Alert Logic Agent Container for Kubernetes, you need your unique registration key. 
+- You must have the kubectl command line interface installed and get authentication credentials to interact with the cluster where you want to install the Agent Container.
+- Download the al-agent-container.yaml file.
+- To deploy the Alert Logic Agent Container for Kubernetes, you need your Alert Logic account's unique registration key.
 
 **To find your unique registration key:**
 1. In the Alert Logic console, click the Support Information icon.
 2. Click "Details."
 3. Copy your unique registration key.
 
-## Deploy the Agent Container 
+## Deploy the Agent Container
 **To deploy the Agent Container to your cluster:**
-1. Edit the al-agent-container.yaml file to replace "your_registration_key_here" with your unique registration key.
+1. Edit the al-agent-container.yaml file to replace "your_registration_key_here" with your Alert Logic account's unique registration key.
 2. In the command line, type  ```kubectl get pods``` to ensure kubectl communicates with the proper Kubernetes cluster.
 3. In the command line, type ```kubectl apply -f al-agent-container.yaml```.
 
 **To verify agent deployment and operation:**
 1. In the command line, type ```kubectl describe daemonset al-agent-container``` to confirm the DaemonSet definition.
 2. In the command line, type ```kubectl get pods``` to confirm the Agent Container pod is running on every expected host in your cluster.
-3. In the command line, in one of the pods, type ```kubectl logs -f <pod name>``` to confirm the Agent Container appears on the list. 
+3. In the command line, in one of the pods, type ```kubectl logs -f <agent's_pod_name>``` to confirm the Agent Container was registered successfully. Example of successful logs:
 
-## Configure the Network Policy Exception in AWS
+```
+Oct 14 02:35:55 2018 al-agent[5]: ALC00083I [alc_config_unregister] clean up registration artefacts
+Oct 14 02:35:55 2018 al-agent[5]: ALC00710I [alc_host_detect_type] No known VM environments detected; local host appears to be standalone
+Oct 14 02:35:55 2018 al-agent[5]: ALC00080I [alc_config_provision_host] Fetched host certificate "/var/alertlogic/etc/host_crt.pem", "/var/alertlogic/etc/host_key.pem"
+
+*** tmhost.conf config ***
+
+source_config {
+  source_id: "2E2A95A1-7827-1005-B5A0-0050568532D4"
+  host_id: "2E132DBA-7827-1005-8BD0-0050568525D9"
+  tm_config {
+    encrypt: false
+    compress: false
+    udp: false
+    packet_size: 0
+  }
+}
+config_version: "958dc91f93dfee2b00ad99556d2c365a702115ff"
+
+*** tmhost.conf config ***
+
+source_config {
+  source_id: "2E2A95A1-7827-1005-B5A0-0050568532D4"
+  host_id: "2E132DBA-7827-1005-8BD0-0050568525D9"
+  tm_config {
+    encrypt: false
+    compress: false
+    udp: false
+    packet_size: 0
+    appliance_assignment {
+      appliance_id: "ABE1B254-7827-1005-8473-0050568505BC"
+      appliance_address {
+        address: "10.138.0.12"
+        port: 443
+      }
+    }
+  }
+}
+```
+
+## Configure the Network Policy Exception in AWS Only
 
 If you use Calico or Weave as a container network interface (CNI), your default network policy could deny the pods access to the AWS EC2 metadata. To avoid this situation, you must add a network policy exception that allows Agent Container pods to access EC2 instance metadata.
 


### PR DESCRIPTION
I was able to test the functionality of our al-agent-container in GCP (GKE to be specific) successfully.

- [x] Provisioning and registration (manual claim using registration key)
- [x] Assignment to an appliance (manually assigned)
- [x] Containers metadata (image, labels, container_id, pods, namespaces, orchestrator_type)
- [x] IDS events and incidents generated
- [x] True source IP extraction
- [x] Application logs collection and parsing
- [x] Web app IDS deny logs generated
- [x] Statistics
- [x] Sources and protected hosts name in the UI (shows the name of the al-agent-container pod, ask customers to append the cluster’s name when deploying the daemonset as a workaround)
- [x] Healthy status remained for more than 24hrs.


