### PR TITLE
Relocate used k8s extension to apps/v1 and specify pod selector

### DIFF
--- a/charts/al-agent/templates/daemonset.yaml
+++ b/charts/al-agent/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -7,6 +7,9 @@ metadata:
 {{ include "al-agent.labels" . | indent 4 }}
   name: {{ include "al-agent.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      app: al-agent-container
   template:
     metadata:
       labels:

--- a/kubernetes/al-agent-container.yaml
+++ b/kubernetes/al-agent-container.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
     app: al-agent-container
   name: al-agent-container
 spec:
+  selector:
+    matchLabels:
+      app: al-agent-container
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR is to solve for:

> Note that in Kubernetes 1.6, some of these objects were relocated from extensions to specific API groups (e.g. apps). When these objects move out of beta, expect them to be in a specific API group like apps/v1. Using extensions/v1beta1 is becoming deprecated—try to use the specific API group where possible

and..

> As of Kubernetes 1.8, you must specify a pod selector that matches the labels of the `.spec.template`. The pod selector will no longer be defaulted when left empty. Selector defaulting was not compatible with `kubectl apply`.

```bash
~/Projects/@alertlogic/al-agent-container on  master
❯ date; kubeval --strict kubernetes/al-agent-container.yaml
Thu Jan 16 14:11:32 CST 2020
PASS - kubernetes/al-agent-container.yaml contains a valid DaemonSet

~/Projects/@alertlogic/al-agent-container on  master
❯ date; helm lint charts/al-agent
Thu Jan 16 14:11:53 CST 2020
==> Linting charts/al-agent
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```