### PR TITLE
Update instructions for containerd and CRI-O deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ If you have not done so already, follow the instructions in the link below to de
 
 **Support for Alert Logic Agent Container Network Intrusion Detection requires the following:**
 - The environment must allow the al-agent-container to run in [privileged mode](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
-- The environment must allow the [mounting of ```docker.sock```](https://docs.docker.com/storage/volumes/) through the volume mounting capability in Docker.
+- The environment must allow the [mounting of ```docker.sock```](https://docs.docker.com/storage/volumes/), ```containerd.sock```, or ```crio.sock``` through the volume mounting capability in your container engine.
 
-Environments that do not permit the above (e.g. [AWS Fargate](fargate/README.md)) usually permit running Alert Logic Agent Container as a sidecar in each task or pod instead, where the agent still has access to that task or pod's network interfaces. Environments that permit privileged mode but do not expose ```docker.sock``` (e.g. raw ```containerd``` environments) are not fully supported. While Alert Logic Agent Container can still be installed in privileged host network mode to capture syslog and network traffic on base host network interfaces, currently it does not discover other containers running on the host, capture traffic from their virtual network interfaces, or collect their native (stdout/stderr) logs.
+Environments that do not permit the above (e.g. [AWS Fargate](fargate/README.md)) usually permit running Alert Logic Agent Container as a sidecar in each task or pod instead, where the agent still has access to that task or pod's network interfaces. Environments that permit privileged mode but do not expose ```docker.sock```, ```containerd.sock```, or ```crio.sock``` are not fully supported. While Alert Logic Agent Container can still be installed in privileged host network mode to capture syslog and network traffic on base host network interfaces, it does not discover other containers running on the host, capture traffic from their virtual network interfaces, or collect their native (stdout/stderr) logs.
 
 **Support for Alert Logic Agent Container Log Management requires the following:**
 - Enable the default Docker logging driver, where the [default is ```json-file```](https://docs.docker.com/config/containers/logging/configure/).
-- The environment must allow the [mounting of ```docker.sock```](https://docs.docker.com/storage/volumes/) through the volume mounting capability in Docker.
+- The environment must allow the [mounting of ```docker.sock```](https://docs.docker.com/storage/volumes/), ```containerd.sock```, or ```crio.sock``` through the volume mounting capability in your container engine.
 
 # Image repository
 

--- a/charts/al-agent/templates/daemonset.yaml
+++ b/charts/al-agent/templates/daemonset.yaml
@@ -38,15 +38,15 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /var/run/docker.sock
-          name: docker-sock-volume
+        - mountPath: "{{ .Values.mounts.containerSocket }}"
+          name: container-sock-volume
         - mountPath: /host/proc
           name: docker-proc-volume
         imagePullPolicy: Always
       volumes:
-      - name: docker-sock-volume
+      - name: container-sock-volume
         hostPath:
-          path: /var/run/docker.sock
+          path: "{{ .Values.mounts.containerSocket }}"
           type: Socket
       - name: docker-proc-volume
         hostPath:

--- a/charts/al-agent/values.yaml
+++ b/charts/al-agent/values.yaml
@@ -23,6 +23,12 @@ tolerations:
   # use this one instead:
   # - operator: "Exists"
 
+mounts:
+  # Specify the socket name to mount for container engine integration
+  # /run/containerd/containerd.sock for containerd
+  # /run/crio/crio.sock for CRI-O
+  containerSocket: /var/run/docker.sock
+
 # You must override this value when deploying the chart for non-AWS/Azure
 # deployments.
 # registration_key: "your_registration_key_here"

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -2,11 +2,16 @@
 
 To deploy the Alert Logic Agent Container on a Kubernetes cluster, you must use a `DaemonSet`, which ensures that one Agent Container runs on each physical node in the Kubernetes cluster.
 
-This directory contains the al-agent-container.yaml file, which is the YAML definition you need to download and edit. This file allows the Kubernetes `DaemonSet` to deploy the agent.
+This directory contains the following files, which are the YAML definitions you need to download and edit. These files allow the Kubernetes `DaemonSet` to deploy the agent.
+- `al-agent-container.yaml`: for Kubernetes clusters running Docker (mounts ```/var/run/docker.sock```)
+- `al-agent-containerd.yaml`: for Kubernetes clusters running containerd (mounts ```/run/containerd/containerd.sock```)
+- `al-agent-crio.yaml`: for Kubernetes/OpenShift clusters running CRI-O (mounts ```/run/crio/crio.sock```)
+
+When upgrading the cluster to a different container engine, the version targeting the current container engine needs to de deleted (`kubectl delete -f <YAML>`), followed by deployment of the version targeting the new engine (see below). It is recommended to do this after the upgrade.
 
 ## Before You Begin
 - You must have the kubectl command line interface installed and get authentication credentials to interact with the cluster where you want to install the Agent Container.
-- Download the al-agent-container.yaml file.
+- Download the YAML file appropriate for your cluster.
 - To deploy the Alert Logic Agent Container for Kubernetes, you need your unique registration key unless the deployment is set up for automatic provisioning.
 
 **To find your unique registration key (MDR platform -- Data Center deployments only):**
@@ -22,7 +27,7 @@ This directory contains the al-agent-container.yaml file, which is the YAML defi
 
 ## Deploy the Agent Container
 **To deploy the Agent Container to your cluster:**
-1. Edit the al-agent-container.yaml file to replace "your_registration_key_here" with the unique registration key. Note that supported cloud deployments with valid credentials do not require registration keys, as provisioning is performed based on cloud metadata gathered by the agent and the Alert Logic back end. When using a supported cloud deployment, the `KEY` environment variable should be undefined.
+1. Edit the chosen YAML file to replace "your_registration_key_here" with the unique registration key. Note that supported cloud deployments with valid credentials do not require registration keys, as provisioning is performed based on cloud metadata gathered by the agent and the Alert Logic back end. When using a supported cloud deployment, the `KEY` environment variable should be undefined.
 2. In the command line, type  ```kubectl get pods``` to ensure kubectl communicates with the proper Kubernetes cluster.
 3. In the command line, type ```kubectl apply -f al-agent-container.yaml```.
 

--- a/kubernetes/al-agent-container.yaml
+++ b/kubernetes/al-agent-container.yaml
@@ -15,40 +15,40 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - name: al-agent-container
-        # See https://hub.docker.com/r/alertlogic/al-agent-container/tags for available images
-        image: alertlogic/al-agent-container:latest
-        resources:
-          requests:
-            memory: "100Mi"
-            cpu: "0.25"
-          limits:
-            memory: "500Mi"
-            cpu: "3"
-        env:
-          - name: KEY
-            value: "your_registration_key_here"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /var/run/docker.sock
-          name: container-sock-volume
-        - mountPath: /host/proc
-          name: docker-proc-volume
-        imagePullPolicy: Always
+        - name: al-agent-container
+          # See https://hub.docker.com/r/alertlogic/al-agent-container/tags for available images
+          image: alertlogic/al-agent-container:latest
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "0.25"
+            limits:
+              memory: "500Mi"
+              cpu: "3"
+          env:
+            - name: KEY
+              value: "your_registration_key_here"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /var/run/docker.sock
+              name: container-sock-volume
+            - mountPath: /host/proc
+              name: docker-proc-volume
+          imagePullPolicy: Always
       volumes:
-      - name: container-sock-volume
-        hostPath:
-          path: /var/run/docker.sock
-          type: Socket
-      - name: docker-proc-volume
-        hostPath:
-          path: /proc
-          type: Directory
+        - name: container-sock-volume
+          hostPath:
+            path: /var/run/docker.sock
+            type: Socket
+        - name: docker-proc-volume
+          hostPath:
+            path: /proc
+            type: Directory
       restartPolicy: Always
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
       # If you want the agent to be deployed on all agents with any posible taints,
       # use this one instead:
       # - operator: "Exists"

--- a/kubernetes/al-agent-containerd.yaml
+++ b/kubernetes/al-agent-containerd.yaml
@@ -15,40 +15,40 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - name: al-agent-container
-        # See https://hub.docker.com/r/alertlogic/al-agent-container/tags for available images
-        image: alertlogic/al-agent-container:latest
-        resources:
-          requests:
-            memory: "100Mi"
-            cpu: "0.25"
-          limits:
-            memory: "500Mi"
-            cpu: "3"
-        env:
-          - name: KEY
-            value: "your_registration_key_here"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /run/containerd/containerd.sock
-          name: container-sock-volume
-        - mountPath: /host/proc
-          name: docker-proc-volume
-        imagePullPolicy: Always
+        - name: al-agent-container
+          # See https://hub.docker.com/r/alertlogic/al-agent-container/tags for available images
+          image: alertlogic/al-agent-container:latest
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "0.25"
+            limits:
+              memory: "500Mi"
+              cpu: "3"
+          env:
+            - name: KEY
+              value: "your_registration_key_here"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /run/containerd/containerd.sock
+              name: container-sock-volume
+            - mountPath: /host/proc
+              name: docker-proc-volume
+          imagePullPolicy: Always
       volumes:
-      - name: container-sock-volume
-        hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
-      - name: docker-proc-volume
-        hostPath:
-          path: /proc
-          type: Directory
+        - name: container-sock-volume
+          hostPath:
+            path: /run/containerd/containerd.sock
+            type: Socket
+        - name: docker-proc-volume
+          hostPath:
+            path: /proc
+            type: Directory
       restartPolicy: Always
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
       # If you want the agent to be deployed on all agents with any posible taints,
       # use this one instead:
       # - operator: "Exists"

--- a/kubernetes/al-agent-containerd.yaml
+++ b/kubernetes/al-agent-containerd.yaml
@@ -31,7 +31,7 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /var/run/docker.sock
+        - mountPath: /run/containerd/containerd.sock
           name: container-sock-volume
         - mountPath: /host/proc
           name: docker-proc-volume
@@ -39,7 +39,7 @@ spec:
       volumes:
       - name: container-sock-volume
         hostPath:
-          path: /var/run/docker.sock
+          path: /run/containerd/containerd.sock
           type: Socket
       - name: docker-proc-volume
         hostPath:

--- a/kubernetes/al-agent-crio.yaml
+++ b/kubernetes/al-agent-crio.yaml
@@ -15,40 +15,40 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - name: al-agent-container
-        # See https://hub.docker.com/r/alertlogic/al-agent-container/tags for available images
-        image: alertlogic/al-agent-container:latest
-        resources:
-          requests:
-            memory: "100Mi"
-            cpu: "0.25"
-          limits:
-            memory: "500Mi"
-            cpu: "3"
-        env:
-          - name: KEY
-            value: "your_registration_key_here"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /run/crio/crio.sock
-          name: container-sock-volume
-        - mountPath: /host/proc
-          name: docker-proc-volume
-        imagePullPolicy: Always
+        - name: al-agent-container
+          # See https://hub.docker.com/r/alertlogic/al-agent-container/tags for available images
+          image: alertlogic/al-agent-container:latest
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "0.25"
+            limits:
+              memory: "500Mi"
+              cpu: "3"
+          env:
+            - name: KEY
+              value: "your_registration_key_here"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /run/crio/crio.sock
+              name: container-sock-volume
+            - mountPath: /host/proc
+              name: docker-proc-volume
+          imagePullPolicy: Always
       volumes:
-      - name: container-sock-volume
-        hostPath:
-          path: /run/crio/crio.sock
-          type: Socket
-      - name: docker-proc-volume
-        hostPath:
-          path: /proc
-          type: Directory
+        - name: container-sock-volume
+          hostPath:
+            path: /run/crio/crio.sock
+            type: Socket
+        - name: docker-proc-volume
+          hostPath:
+            path: /proc
+            type: Directory
       restartPolicy: Always
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
       # If you want the agent to be deployed on all agents with any posible taints,
       # use this one instead:
       # - operator: "Exists"

--- a/kubernetes/al-agent-crio.yaml
+++ b/kubernetes/al-agent-crio.yaml
@@ -31,7 +31,7 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /var/run/docker.sock
+        - mountPath: /run/crio/crio.sock
           name: container-sock-volume
         - mountPath: /host/proc
           name: docker-proc-volume
@@ -39,7 +39,7 @@ spec:
       volumes:
       - name: container-sock-volume
         hostPath:
-          path: /var/run/docker.sock
+          path: /run/crio/crio.sock
           type: Socket
       - name: docker-proc-volume
         hostPath:


### PR DESCRIPTION
Instructions to accompany the agent 1.21.0 release, introducing support for containerd and CRI-O integration.

Rebase from internal development by @akontsevoy
